### PR TITLE
Convention for schema reg

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,18 +8,27 @@ Kafka console consumer in Go. Supports Avro and MessagePack decoding.
 
 ## Usage
 
+To get help run: `tailtopic -h`
+
     Usage: tailtopic <options> topicname
 
     Options:
       -b string
-            One of the Kafka brokers host:port (default "localhost:9092")
+            One of the Kafka brokers host[:port] (default "localhost:9092")
       -d string
             Message decoder. Either "avro", "msgpack" or "none" (default "none")
       -o string
             Offset to start consuming from. Either "earliest" or "latest" (default "latest")
       -s string
-            Avro Schema registry URI (default "http://localhost:8081")
+            Avro Schema registry URI. If not provided, Kafka broker host will be used (default "http://{kafkabroker}:8081")
 
+For example, to tail *tracking* topic with MessagePack serialized messages and if *kfk001* is one of the Kafka broker:
+
+    tailtopic -b kfk001 -d msgpack tracking
+
+For example, to tail *client_request_v1* topic with Avro serialized messages and if *kfk001* is one of the Kafka broker and the schema registry is reachable on the same host:
+
+    tailtopic -b kfk001 -d avro client_request_v1
 
 ## Development
 

--- a/cmd/tailtopic/main.go
+++ b/cmd/tailtopic/main.go
@@ -17,8 +17,8 @@ func usage() {
 
 func main() {
 	flag.Usage = usage
-	broker := flag.String("b", "localhost:9092", "One of the Kafka brokers host:port")
-	schemaregURI := flag.String("s", "http://localhost:8081", "Avro Schema registry URI")
+	broker := flag.String("b", "localhost:9092", "One of the Kafka brokers host[:port]")
+	schemaregURI := flag.String("s", "http://{kafkabroker}:8081", "Avro Schema registry URI. If not provided, Kafka broker host will be used")
 	offset := flag.String("o", "latest", `Offset to start consuming from. Either "earliest" or "latest"`)
 	decoder := flag.String("d", "none", `Message decoder. Either "avro", "msgpack" or "none"`)
 

--- a/tailtopic_test.go
+++ b/tailtopic_test.go
@@ -61,3 +61,25 @@ func TestStart(t *testing.T) {
 		}
 	}
 }
+
+func Test_getHost(t *testing.T) {
+	examples := []struct {
+		brokerIn     string
+		schemaregIn  string
+		brokerOut    string
+		schemaregOut string
+	}{
+		{"kfk001", "http://{broker}:8081", "kfk001:9092", "http://kfk001:8081"},
+		{"kfk001:9092", "http://{broker}:8081", "kfk001:9092", "http://kfk001:8081"},
+	}
+
+	for _, example := range examples {
+		b, s := getHosts(example.brokerIn, example.schemaregIn)
+		if b != example.brokerOut {
+			t.Errorf("Failed! expected=%s, actual=%s", example.brokerOut, b)
+		}
+		if s != example.schemaregOut {
+			t.Errorf("Failed! expected=%s, actual=%s", example.schemaregOut, s)
+		}
+	}
+}


### PR DESCRIPTION
* Use broker host as default schema-registry host
* Provide default kafka port so it's not required